### PR TITLE
chore: add Claude Code project configuration

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,54 @@
+---
+name: code-reviewer
+description: Read-only code reviewer for performance, style, and architecture
+tools:
+  - Read
+  - Glob
+  - Grep
+---
+
+# Code Reviewer Agent
+
+You are a read-only code reviewer for faizaan.tech, an audiovisual portfolio site. You review changes but do not modify files.
+
+## Review Criteria
+
+### Performance
+
+- Animation state must use `useRef`, never `useState`
+- Per-frame updates must use direct DOM manipulation (`ref.current.style.*`)
+- Frequency data should be memoized with `useMemo`
+- Update functions should be wrapped in `useCallback`
+- No object allocations inside animation loops or `useFrame`
+- No CSS transitions on properties animated per-frame
+- Three.js: use `useFrame`, never raw `requestAnimationFrame`
+
+### Code Style
+
+- Import order: React/libraries → local styled imports → context/hooks → types
+- Type-only imports use `import type { ... }`
+- Component directory structure: `index.tsx` + `*.styled.ts`
+- Styled-components: transient props use `$` prefix
+- No unused imports or variables
+
+### Audio Integration
+
+- Frequency bin names must match: `senior`, `software`, `engineer`, `fullstack`, `london`, `affirm`
+- Smoothing factors should be reasonable (0.1-0.9)
+- Values should be normalized to expected ranges (frequency 0-255, normalized 0-1)
+- Bass intensity uses RMS of senior+software bins
+
+### Architecture
+
+- Z-index layering must be respected (Background:0 → GlassPanel:1 → Canvas:10 → Social:20 → PlayButton:1000)
+- No circular dependencies
+- Audio data flows one way: MusicAnalyser → AudioProvider → components via useAudio()
+- New components should follow the AnimatedSubtitle pattern
+
+### Common Pitfalls
+
+- Using `useState` for animation values (causes re-renders every frame)
+- Adding CSS transitions on animated properties (fights with direct DOM updates)
+- Creating new Three.js objects (Vector3, Material) inside `useFrame`
+- Forgetting to normalize frequency data (raw values are 0-255)
+- Using wrong frequency bin names (they're themed, not descriptive)

--- a/.claude/agents/creative-dev.md
+++ b/.claude/agents/creative-dev.md
@@ -1,0 +1,66 @@
+---
+name: creative-dev
+description: Animation, 3D, and audio specialist for audiovisual features
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
+---
+
+# Creative Dev Agent
+
+You are an animation/3D/audio specialist working on faizaan.tech, an audiovisual portfolio site built with React, Three.js (via React Three Fiber), and the Web Audio API.
+
+## Your Responsibilities
+
+- Audio-reactive animations and visual effects
+- Three.js/R3F 3D work (models, materials, lighting)
+- Audio pipeline modifications (frequency analysis, BPM detection)
+- Tuning animation parameters (smoothing, intensity, timing)
+
+## Audio Pipeline
+
+```
+PlayButton → AudioContext.startMusic(bpm) → MusicPlayer loads audio
+  → MusicAnalyser.getFrequencyData() → setAudioData() → components via useAudio()
+```
+
+Key files:
+- `src/components/MusicPlayer/MusicAnalyser.ts` — FFT, frequency bins, BPM
+- `src/components/MusicPlayer/index.ts` — Analysis loop, bass intensity
+- `src/context/AudioContext.tsx` — AudioData interface, provider
+- `src/components/Head/index.tsx` — 3D head, BPM nodding
+
+## Frequency Bins
+
+| Bin | Hz | Musical Role |
+|-----|-----|-------------|
+| `senior` | 0-100 | Sub-bass (kick drums) |
+| `software` | 100-250 | Bass (bass lines) |
+| `engineer` | 250-500 | Low-mid (lower vocals) |
+| `fullstack` | 500-1000 | Mid (vocals, snare) |
+| `london` | 1000-2000 | High-mid (vocal clarity) |
+| `affirm` | 2000-20000 | Treble (cymbals, air) |
+
+## Smoothing & Intensity
+
+- Exponential smoothing: `smoothed = prev * (1 - factor) + new * factor`
+- AnimatedSubtitle: factor 0.15 (smooth), AnimatedHeader: factor 0.6 (responsive)
+- Bass intensity: RMS of senior+software bins, smoothed at 0.15
+- Head nod intensity: cubic curve (`bassIntensity^3`), range 0.1-0.5
+
+## Three.js Patterns
+
+- Use `useFrame` for animation (never raw `requestAnimationFrame`)
+- Use `useRef` for mutable state between frames
+- Current head: orange metallic material (metalness 0.9, roughness 0)
+- BPM sync: sine wave at `bpm/60 * PI * 2` frequency
+
+## Testing
+
+Run `yarn dev`, click the play button, verify visual behavior. No automated tests for visual output.

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -1,0 +1,62 @@
+---
+name: frontend-dev
+description: React and styled-components specialist for UI work
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
+---
+
+# Frontend Dev Agent
+
+You are a React/TypeScript/styled-components specialist working on faizaan.tech, an audiovisual portfolio site.
+
+## Your Responsibilities
+
+- Build and modify React components
+- Create and update styled-components
+- Manage component composition and layout
+- Handle state management with AudioProvider/useAudio
+
+## Component Conventions
+
+- Each component: directory with `index.tsx` + `*.styled.ts`
+- Use styled-components v6 with transient props (`$propName`)
+- Import order: React/libraries → local styled imports → context/hooks → types
+- Use `import type { ... }` for type-only imports
+
+## Z-Index Layers
+
+| z-index | Component(s) |
+|---------|-------------|
+| 0 | Background |
+| 1 | GlassPanel, AnimatedHeader, AnimatedSubtitle |
+| 10 | Canvas (Three.js) |
+| 20 | SocialIconsContainer |
+| 1000 | PlayButton |
+
+## State Patterns
+
+- App-level audio state: `AudioProvider` + `useAudio()` hook
+- Animation state: Always `useRef`, never `useState`
+- Direct DOM manipulation for per-frame animation (`ref.current.style.*`)
+- No CSS transitions on animated properties
+
+## Theme
+
+- `src/styles/theme.ts` — exports `theme` with `colors` and `spacing`
+- `src/styles/colors.ts` — primary, secondary, neutral, status color palettes
+- Access in styled-components via `${({ theme }) => theme.colors.*}`
+
+## Validation
+
+After changes, run:
+```
+yarn build   # Must pass (tsc + vite build)
+yarn lint    # Must pass (eslint)
+```

--- a/.claude/skills/3d-model/SKILL.md
+++ b/.claude/skills/3d-model/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: 3d-model
+description: Checklist for Three.js and React Three Fiber work
+---
+
+# Three.js / React Three Fiber Work
+
+Key file: `src/components/Head/index.tsx`
+
+## Model Loading
+
+Uses `OBJLoader` from `three/examples/jsm/Addons.js`:
+1. Load model from `/src/assets/head.obj`
+2. Center at origin: compute bounding box, subtract center
+3. Traverse children, apply material to each `Mesh`
+4. Store in state via `useState<Group | null>`
+
+## Current Material Config
+
+```ts
+new MeshStandardMaterial({
+  color: "orange",
+  metalness: 0.9,
+  roughness: 0,
+  emissive: "orange",
+  emissiveIntensity: 0.2,
+})
+```
+
+## Lighting Setup (in App.tsx)
+
+```tsx
+<ambientLight intensity={5} />
+<pointLight position={[10, 10, 10]} intensity={20} distance={20} decay={2} />
+<pointLight position={[-5, -5, -5]} intensity={5} />
+```
+
+## Animation with useFrame
+
+Always use `useFrame` for animation — never raw `requestAnimationFrame`:
+
+```tsx
+useFrame(({ pointer, clock }) => {
+  if (!meshRef.current) return;
+  // animation logic here
+});
+```
+
+Use `useRef` for mutable state between frames (not `useState`).
+
+## BPM-Synced Motion
+
+The head nods to the beat using a sine wave:
+
+```
+sineValue = sin(timeSinceMusicStart * (bpm / 60) * PI * 2)
+nodAngle = sineValue * maxNodAngle * intensityMultiplier
+```
+
+- Intensity updates only at direction changes (peak/trough detection via sign change)
+- Bass intensity mapped through cubic curve: `intensity^3`
+- Multiplier range: 0.1 (quiet) to 0.5 (loud bass)
+
+## Mouse Interaction
+
+Pointer NDC coordinates (-1 to 1) → rotation:
+- Vertical: `mouseY * 0.15` → pitch (rotation.x)
+- Horizontal: `mouseX * 0.2` → yaw (rotation.y)
+- Combined with BPM nodding for final rotation
+- Clamped to `[-maxNodAngle, maxNodAngle]` for X and `[-0.5, 0.5]` for Y
+
+## Current Head Transform
+
+```tsx
+<primitive
+  object={obj}
+  scale={0.25}
+  position={[0, -2.5, 0]}
+  rotation={[Math.PI / 2, Math.PI, 0]}
+/>
+```
+
+## Canvas Setup
+
+In `App.tsx`, the Canvas uses fixed positioning with z-index 10:
+```tsx
+<Canvas style={{ position: "fixed", top: 0, left: 0, width: "100%", height: "100%", zIndex: 10 }}>
+```
+
+## Performance Tips
+
+- Use `useRef` for animation state, not `useState`
+- Avoid creating new objects (Vector3, Material) inside `useFrame`
+- Track music start time with `useRef<number | null>` to avoid reset on re-render
+- Use `useEffect` to detect music state changes, store timing in ref

--- a/.claude/skills/audio-analysis/SKILL.md
+++ b/.claude/skills/audio-analysis/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: audio-analysis
+description: Checklist for modifying the audio analysis pipeline
+---
+
+# Modify Audio Pipeline
+
+Key files:
+- `src/components/MusicPlayer/MusicAnalyser.ts` — FFT analysis, frequency bins, BPM detection
+- `src/components/MusicPlayer/index.ts` — Audio loading, analysis loop, bass intensity
+- `src/context/AudioContext.tsx` — AudioData interface, provider, useAudio hook
+- `src/components/MusicPlayer/songs.ts` — Song list with BPM metadata
+
+## Adding/Modifying Frequency Bins
+
+In `MusicAnalyser.ts`, update the `frequencyRanges` object:
+
+```ts
+const frequencyRanges = {
+  senior:    { min: 0,    max: 100 },    // sub-bass
+  software:  { min: 100,  max: 250 },    // bass
+  engineer:  { min: 250,  max: 500 },    // low-mid
+  fullstack: { min: 500,  max: 1000 },   // mid
+  london:    { min: 1000, max: 2000 },   // high-mid
+  affirm:    { min: 2000, max: 20000 },  // treble
+};
+```
+
+Bins auto-convert to FFT indices: `index = (hz / nyquist) * bufferLength`.
+
+## FFT Parameters
+
+In `MusicAnalyser.ts` constructor:
+- `fftSize`: 2048 (gives 1024 frequency bins, ~21Hz resolution at 44.1kHz)
+- `smoothingTimeConstant`: 0.6 (built-in browser smoothing, 0=none, 1=max)
+
+## Data Normalization
+
+`normaliseData()` in `MusicAnalyser.ts`:
+1. Splits bin data into 3 equal chunks (low/mid/high of that range)
+2. For each chunk: `stableValue = avgValue * 0.8 + maxValue * 0.2`
+3. Returns array of ~3 values per bin
+
+## Bass Intensity Calculation
+
+In `MusicPlayer/index.ts`, inside the analysis loop:
+1. Combine `senior` + `software` bin data
+2. Calculate RMS: `sqrt(sumOfSquares / count)`
+3. Normalize to 0-1: `min(rms / 255, 1)`
+4. Smooth: factor 0.15, initialized to `BASE_NOD_INTENSITY` (0.1)
+
+## BPM Detection
+
+`BPMDetector` class in `MusicAnalyser.ts`:
+- Energy threshold: 60th percentile of recent energies (`sortedEnergies.length * 0.6`)
+- Min beat interval: 350ms (max ~171 BPM)
+- Recent energies buffer: 43 frames (~1 second)
+- Beat times buffer: 10 beats
+- Required beats for BPM: 4 minimum
+- Currently uses static BPM from `songs.ts` instead of detected BPM
+
+## Adding a New Audio Metric
+
+1. Add field to `AudioData` interface in `AudioContext.tsx`
+2. Add default value in `defaultAudioData`
+3. Calculate in MusicPlayer's `analyzeFrame` loop
+4. Include in `setAudioData()` call
+5. Consume via `useAudio()` in target component
+
+## Adding a New Song
+
+In `src/components/MusicPlayer/songs.ts`:
+1. Import the audio file: `import name from "../../assets/audio/name.mp3";`
+2. Add to `SONGS` array: `{ file: name, name: "Display Name", bpm: 120 }`
+3. Update `SONG_INDEX` if needed
+
+Current songs:
+- Bend (Tiesto) — 134 BPM
+- Empty Lightning — 113 BPM (currently active, index 1)
+- Expression On Your Face — 133 BPM
+- Generate Utopia — 150 BPM
+- Void — 150 BPM
+- In My Heart — 150 BPM

--- a/.claude/skills/create-animation/SKILL.md
+++ b/.claude/skills/create-animation/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: create-animation
+description: Step-by-step workflow for creating new audio-reactive components
+---
+
+# Create Audio-Reactive Component
+
+Follow these steps in order. Reference `src/components/AnimatedSubtitle/index.tsx` as the canonical pattern.
+
+## Steps
+
+### 1. Create component directory
+
+Create `src/components/<Name>/index.tsx` and `src/components/<Name>/<Name>.styled.ts`.
+
+### 2. Connect to audio
+
+```tsx
+import { useAudio } from "../../context/AudioContext";
+
+const { audioData } = useAudio();
+```
+
+### 3. Set up refs for animation state
+
+Use `useRef` for ALL per-frame values. Never `useState` for animation — it causes re-renders.
+
+```tsx
+const ref = useRef<HTMLDivElement>(null);
+const lastValueRef = useRef(0);
+```
+
+### 4. Memoize frequency data
+
+```tsx
+const frequencyData = useMemo(() => {
+  return audioData.frequencyBins[frequencyBin] || [];
+}, [audioData.frequencyBins, frequencyBin]);
+```
+
+Available bins: `senior` (sub-bass), `software` (bass), `engineer` (low-mid), `fullstack` (mid), `london` (high-mid), `affirm` (treble).
+
+### 5. Create update function with useCallback
+
+Manipulate DOM directly — never trigger React re-renders in the animation loop:
+
+```tsx
+const updateAnimation = useCallback((smoothedValue: number) => {
+  if (!ref.current) return;
+  ref.current.style.opacity = `${0.6 + smoothedValue * 0.4}`;
+  ref.current.style.transform = `scale(${0.95 + smoothedValue * 0.1})`;
+}, []);
+```
+
+### 6. Apply exponential smoothing in useEffect
+
+```tsx
+useEffect(() => {
+  if (frequencyData.length === 0) return;
+
+  const maxValue = Math.max(...frequencyData);
+  const normalizedValue = maxValue / 255;
+
+  const smoothingFactor = 0.15; // 0.1=smooth, 0.9=responsive
+  const smoothedValue =
+    lastValueRef.current * (1 - smoothingFactor) +
+    normalizedValue * smoothingFactor;
+  lastValueRef.current = smoothedValue;
+
+  updateAnimation(smoothedValue);
+}, [frequencyData, updateAnimation]);
+```
+
+### 7. Create styled component
+
+In the `.styled.ts` file. Do NOT add CSS transitions on animated properties:
+
+```tsx
+export const Container = styled.div`
+  position: fixed;
+  /* NO transition on opacity, transform, or other animated props */
+`;
+```
+
+### 8. Render with transition: "none"
+
+```tsx
+return (
+  <Styled.Container
+    ref={ref}
+    style={{ transition: "none" }}
+  >
+    {children}
+  </Styled.Container>
+);
+```
+
+### 9. Add to App.tsx
+
+Import and place at the correct z-index layer:
+- Background (z:0) → GlassPanel (z:1) → Canvas (z:10) → Social (z:20) → PlayButton (z:1000)
+
+### 10. Test
+
+Run `yarn dev`, click the play button, verify the component reacts to music.
+
+## Checklist
+
+- [ ] Uses `useRef` for all animation state (not `useState`)
+- [ ] Frequency data memoized with `useMemo`
+- [ ] Update function wrapped in `useCallback`
+- [ ] DOM manipulation is direct (`ref.current.style.*`)
+- [ ] No CSS transitions on animated properties
+- [ ] Smoothing factor chosen appropriately
+- [ ] Added to App.tsx at correct z-index layer
+- [ ] `yarn build` passes

--- a/.claude/skills/sync-claude-config/SKILL.md
+++ b/.claude/skills/sync-claude-config/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: sync-claude-config
+description: Keep CLAUDE.md, skills, and agents in sync with source code changes
+---
+
+# Sync Claude Config
+
+Run this after significant refactors to keep configuration files accurate.
+
+## Steps
+
+### 1. Read current source values
+
+Read these files and extract current values:
+
+| File | Values to Extract |
+|------|------------------|
+| `src/context/AudioContext.tsx` | `AudioData` interface fields, default values |
+| `src/components/MusicPlayer/MusicAnalyser.ts` | `frequencyRanges` object, FFT params, normalization logic |
+| `src/components/MusicPlayer/index.ts` | Bass intensity calculation, smoothing factor |
+| `src/components/MusicPlayer/songs.ts` | `SONGS` array, `SONG_INDEX` |
+| `src/components/Head/index.tsx` | Material config, nod params, mouse influence values, transform |
+| `src/components/AnimatedSubtitle/index.tsx` | Smoothing factor, animation ranges |
+| `src/components/AnimatedHeader/index.tsx` | Timing params (threshold, cycle duration, random chance), smoothing factor |
+| `src/App.tsx` | Component list, z-index values, lighting setup |
+| `src/styles/theme.ts` | Theme structure |
+| `src/styles/colors.ts` | Color values |
+
+### 2. Compare against config files
+
+Check each config file for drift:
+
+- `./CLAUDE.md` — frequency bins table, z-index table, key files table, dev commands
+- `.claude/skills/create-animation/SKILL.md` — bin names, smoothing example, z-index order
+- `.claude/skills/tune-animation/SKILL.md` — smoothing factors, intensity params, bin table, value ranges
+- `.claude/skills/audio-analysis/SKILL.md` — frequency ranges, FFT params, normalization, BPM params, song list
+- `.claude/skills/3d-model/SKILL.md` — material config, lighting values, transform, mouse values
+- `.claude/agents/frontend-dev.md` — component list, z-index values
+- `.claude/agents/creative-dev.md` — bin names, key file paths, param values
+
+### 3. Report drift
+
+List any differences found, grouped by config file.
+
+### 4. Update config files
+
+Apply corrections to all affected files to match current source.
+
+### 5. Verify
+
+Run `yarn lint && yarn build` to confirm no source files were accidentally modified.

--- a/.claude/skills/tune-animation/SKILL.md
+++ b/.claude/skills/tune-animation/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tune-animation
+description: Checklist for tuning audio-reactive animation parameters
+---
+
+# Tune Animation Parameters
+
+## Smoothing Factor
+
+Formula: `smoothed = prev * (1 - factor) + newValue * factor`
+
+| Factor | Feel | Used By |
+|--------|------|---------|
+| 0.1-0.15 | Very smooth, stable | AnimatedSubtitle (0.15), bassIntensity (0.15) |
+| 0.3-0.5 | Balanced | General purpose |
+| 0.6-0.9 | Responsive, jittery | AnimatedHeader (0.6) |
+
+## Intensity Curves
+
+- **Linear**: `value = input` — proportional response, good for subtle effects
+- **Exponential (cubic)**: `value = Math.pow(input, 3)` — quiet at low levels, dramatic at high levels. Used by Head nod intensity mapping.
+- **Squared**: `value = Math.pow(input, 2)` — middle ground
+
+## Frequency Bin Selection
+
+| Bin | Hz | Responds To |
+|-----|----|-------------|
+| `senior` | 0-100 | Kick drums, deep bass |
+| `software` | 100-250 | Bass lines, bass guitar |
+| `engineer` | 250-500 | Lower vocals, guitar body |
+| `fullstack` | 500-1000 | Vocals, snare |
+| `london` | 1000-2000 | Vocal clarity, hi-hats |
+| `affirm` | 2000-20000 | Cymbals, brightness, air |
+
+Combine bins for broader response: `[...seniorData, ...softwareData]` (see bassIntensity in MusicPlayer).
+
+## AnimatedHeader Timing Params
+
+| Param | Value | Effect |
+|-------|-------|--------|
+| `CHANGE_THRESHOLD` | 0.03 | Min smoothed value change to trigger font switch |
+| `FORCE_CYCLE_DURATION` | 2000ms | Force font change if no audio activity |
+| `RANDOM_CHANGE_CHANCE` | 0.15 | Probability of triggering consecutive rapid changes |
+
+## Head Nod Params
+
+| Param | Value | Effect |
+|-------|-------|--------|
+| `BASE_NOD_INTENSITY` | 0.1 | Minimum nod amplitude (10%) |
+| `NOD_INTENSITY_MULTIPLIER` | 0.4 | Max additional nod from bass (so max = 0.5) |
+| `maxNodAngle` | PI/9 (20deg) | Maximum rotation angle |
+| Mouse influence X | 0.15 | Vertical mouse → head pitch |
+| Mouse influence Y | 0.2 | Horizontal mouse → head yaw |
+
+## Value Ranges
+
+| Value | Range | Notes |
+|-------|-------|-------|
+| Raw frequency data | 0-255 | From `getByteFrequencyData` |
+| Normalized frequency | 0-1 | After `/255` |
+| `bassIntensity` | 0-1 | RMS of senior+software, smoothed |
+| Nod multiplier | 0.1-0.5 | `BASE_NOD_INTENSITY + NOD_INTENSITY_MULTIPLIER * intensity^3` |
+
+## Performance Checklist
+
+- [ ] Animation state in `useRef` (not `useState`)
+- [ ] Direct DOM manipulation (`ref.current.style.*`)
+- [ ] Frequency data memoized with `useMemo`
+- [ ] No CSS transitions on animated properties
+- [ ] No object allocations inside animation loops
+- [ ] Update function in `useCallback`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# faizaan.tech v2
+
+Personal audiovisual portfolio site. A 3D head nods to music while typography and UI elements react to audio frequencies in real-time.
+
+## Dev Commands
+
+```
+yarn dev          # Vite dev server
+yarn build        # tsc -b && vite build
+yarn lint         # eslint .
+yarn preview      # Preview production build
+```
+
+## Audio Pipeline
+
+```
+PlayButton → AudioContext.startMusic(bpm) → MusicPlayer loads audio file
+  → MusicAnalyser.getFrequencyData() → setAudioData() → components via useAudio()
+```
+
+- `AudioProvider` wraps the app and holds `AudioData` state (bpm, frequencyBins, isPlaying, bassIntensity)
+- `MusicPlayer` runs a `requestAnimationFrame` loop calling `MusicAnalyser` each frame
+- Components consume data via `useAudio()` hook from `src/context/AudioContext.tsx`
+
+## Frequency Bins
+
+Defined in `src/components/MusicPlayer/MusicAnalyser.ts`:
+
+| Bin Name     | Range (Hz)   | Musical Role |
+|-------------|-------------|--------------|
+| `senior`    | 0-100       | Sub-bass     |
+| `software`  | 100-250     | Bass         |
+| `engineer`  | 250-500     | Low-mid      |
+| `fullstack` | 500-1000    | Mid          |
+| `london`    | 1000-2000   | High-mid     |
+| `affirm`    | 2000-20000  | Treble       |
+
+Each bin is normalized to ~3 values via 3-segment chunking (80% avg + 20% max blend).
+
+## Component Layers (z-index order)
+
+| Layer            | z-index | Component(s)                    |
+|-----------------|---------|--------------------------------|
+| Background      | 0       | `Background`                   |
+| GlassPanel      | 1       | `GlassPanel`                   |
+| Header/Subtitle | 1       | `AnimatedHeader`, `AnimatedSubtitle` |
+| Canvas (3D)     | 10      | Three.js `Canvas` with `Head`  |
+| Social Icons    | 20      | `SocialIconsContainer`         |
+| Play Button     | 1000    | `PlayButton`                   |
+
+## State & Animation Patterns
+
+- **State**: `AudioProvider` uses `useState` for audio data. Components read via `useAudio()`.
+- **Animation state**: Always `useRef` for per-frame values (never `useState` — avoids re-renders).
+- **Direct DOM manipulation**: Animated components set `ref.current.style.*` directly in `useEffect`.
+- **Exponential smoothing**: `smoothed = prev * (1 - factor) + newValue * factor`
+  - Lower factor (0.1-0.15) = smoother/stable (AnimatedSubtitle uses 0.15)
+  - Higher factor (0.6-0.9) = more responsive (AnimatedHeader uses 0.6)
+- **No CSS transitions** on properties being animated per-frame (set `transition: "none"`).
+- **Three.js**: Use `useFrame` for animation loops (never raw `requestAnimationFrame`). Use refs for mutable state.
+
+## Code Conventions
+
+- **Components**: Each component gets a directory with `index.tsx` + `*.styled.ts`
+- **Styled components**: Use `styled-components` v6 with transient props (`$propName`)
+- **Imports**: React/libraries first, then local (`../../App.styled`), then context (`../../context/AudioContext`)
+- **Type imports**: Use `import type { ... }` for type-only imports
+- **Theme**: `src/styles/theme.ts` exports `theme` with `colors` and `spacing`
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/App.tsx` | Root layout, component composition, Canvas/lighting setup |
+| `src/context/AudioContext.tsx` | AudioProvider, useAudio hook, AudioData interface |
+| `src/components/MusicPlayer/MusicAnalyser.ts` | FFT analysis, frequency bins, BPM detection |
+| `src/components/MusicPlayer/index.ts` | Audio loading, analysis loop, bass intensity calc |
+| `src/components/MusicPlayer/songs.ts` | Song list with BPM metadata |
+| `src/components/Head/index.tsx` | 3D head model, BPM-synced nodding |
+| `src/components/AnimatedSubtitle/index.tsx` | Canonical audio-reactive component pattern |
+| `src/components/AnimatedHeader/index.tsx` | Font-cycling header with audio reactivity |
+
+## Deployment
+
+Netlify. Build command: `yarn build`. Publish directory: `dist`.


### PR DESCRIPTION
## Summary

- Add project-level `CLAUDE.md` with dev commands, audio pipeline architecture, frequency bin reference, z-index layers, animation patterns, and code conventions
- Add 5 skills: `create-animation`, `tune-animation`, `audio-analysis`, `3d-model`, `sync-claude-config`
- Add 3 agents: `frontend-dev` (full tools), `creative-dev` (full tools), `code-reviewer` (read-only)

## Test plan

- [ ] Start a new Claude Code session in the repo — `CLAUDE.md` should load automatically
- [ ] Verify skills are available: `/create-animation`, `/tune-animation`, `/audio-analysis`, `/3d-model`, `/sync-claude-config`
- [ ] Verify agents appear when using Task tool
- [ ] No source code changes — `yarn build` output unchanged from `v2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)